### PR TITLE
Remove scrollbars

### DIFF
--- a/main.css
+++ b/main.css
@@ -2,7 +2,7 @@ body {
   font-family: Helvetica, Arial;
   background: #0DC081;
   color: #FFFFFF;
-
+  margin: 0 0;
 }
 
 a:link {


### PR DESCRIPTION
Currently in Chrome the scrollbars are always displayed, because `body` has a default margin:

![image](https://user-images.githubusercontent.com/1793699/45555739-e5a14c00-b839-11e8-9f6a-459b28298c95.png)

:fire::fire::fire: Away with the scrollbars! :fire::fire::fire: