### PR TITLE
Update to Open Source Policy 1.0.3

### DIFF
--- a/suse-open-source-policy.html
+++ b/suse-open-source-policy.html
@@ -93,21 +93,21 @@
 
     <h2 id="open-source">Open Source</h2>
 
-    <p>Open Source is at the heart of the SUSE business and development model. We believe that Open Source is not a zero-sum game but that collaboration in the open benefits all participants and creates a broader base for everybody to build upon. SUSE is proud to be a good citizen and leader of the global open source community. Our approach to Open Source is “Open Source first, upstream first”.</p>
+    <p>Open Source is at the heart of the SUSE business and development model. We believe that Open Source is not a zero-sum game but that collaboration in the open benefits all participants and creates a broader base for everybody to build upon. SUSE is proud to be a good citizen and leader of the global open source community. Our approach to Open Source is "Open Source first, upstream first".</p>
 
-    <p>This document provides transparency on how SUSE operates and outlines our engineer’s guidelines on how to deal with Open Source. It might also serve as inspiration for others implementing Open Source policies.</p>
+    <p>This document provides transparency on how SUSE operates and outlines our engineer's guidelines on how to deal with Open Source. It might also serve as inspiration for others implementing Open Source policies.</p>
 
-    <p>SUSE uses the term “Open Source” for brevity and because it is the clearest descriptor in the context we are operating in. We do recognize that Open Source is more than just a development model and that there are ideals behind it, the ideals to respect users’ freedoms and community, and specifically the freedoms to use, study, share, and improve software. SUSE has many engineers passionately standing behind the ideals of Free and Open Source Software and support these ideals as a company.</p>
+    <p>SUSE uses the term "Open Source" for brevity and because it is the clearest descriptor in the context we are operating in. We do recognize that Open Source is more than just a development model and that there are ideals behind it, the ideals to respect users' freedoms and community, and specifically the freedoms to use, study, share, and improve software. SUSE has many engineers passionately standing behind the ideals of Free and Open Source Software and support these ideals as a company.</p>
 
-    <p>When we discuss Open Source Software we refer to the definition of <a href="https://opensource.org/licenses">Open Source Licenses by the Open Source Initiative (“OSI”)</a>. SUSE considers software, including its documentation, released under a license that is compatible with OSI’s Open Source Definition to be Open Source.</p>
+    <p>When we discuss Open Source Software we refer to the definition of <a href="https://opensource.org/licenses">Open Source Licenses by the Open Source Initiative ("OSI")</a>. SUSE considers software, including its documentation, released under a license that is compatible with OSI's Open Source Definition to be Open Source.</p>
 
     <h2 id="producing-open-source-software">Producing Open Source Software</h2>
 
-    <p>We develop in the open and publish our code as Open Source. SUSE products are fully Open Source. There are only rare exceptions where we don’t release code as Open Source. Our development model is designed around Open Source to make it easy for our engineers to produce and contribute to Open Source software.</p>
+    <p>We develop in the open and publish our code as Open Source. SUSE products are fully Open Source. There are only rare exceptions where we don't release code as Open Source. Our development model is designed around Open Source to make it easy for our engineers to produce and contribute to Open Source software.</p>
 
     <h3 id="contributing-to-open-source-projects">Contributing to Open Source Projects</h3>
 
-    <p>SUSE considers itself as part of the global Open Source community. When we fix bugs or make other changes we operate under the maxime “upstream first”. That means we contribute all changes back to the community as early as possible so that they become part of the common base we build on.</p>
+    <p>SUSE considers itself as part of the global Open Source community. When we fix bugs or make other changes we operate under the maxime "upstream first". That means we contribute all changes back to the community as early as possible so that they become part of the common base we build on.</p>
 
     <h4 id="contributing-patches">Contributing Patches</h4>
 
@@ -115,7 +115,7 @@
 
     <h4 id="contributing-non-code">Contributing Non-Code</h4>
 
-    <p>There are many ways to contribute to Open Source projects other than writing code: Writing documentation, reporting bugs, helping users, discussing development, etc. Apply the spirit of the guideline here as well. Be open, respectful, and collaborate.</p>
+    <p>There are many ways to contribute to Open Source projects other than writing code: Writing documentation, reporting bugs, helping users, discussing development, etc. Apply the spirit of the guideline here as well. Be open, respectful, and collaborate. Use the agreed/accepted license of the upstream project also for non-code contributions provided it is a license that is compatible with the Open Source Definition.</p>
 
     <h4 id="contributor-licensing-agreements">Contributor Licensing Agreements</h4>
 
@@ -129,7 +129,7 @@
 
     <h3 id="creating-new-projects">Creating new projects</h3>
 
-    <p>Part of our “upstream first” philosophy is that we collaborate with and contribute to, upstream projects for new things too. Before starting a new project, review existing projects and evaluate if something which already exists could be used or the project could become an extension or part of an existing upstream project.</p>
+    <p>Part of our "upstream first" philosophy is that we collaborate with and contribute to, upstream projects for new things too. Before starting a new project, review existing projects and evaluate if something which already exists could be used or the project could become an extension or part of an existing upstream project.</p>
 
     <p>When SUSE starts new projects we usually publish them as Open Source. The standard place for that is GitHub. We have two principal organizations there: SUSE and openSUSE.</p>
 
@@ -137,19 +137,19 @@
 
     <p>For projects which have maintainers or co-maintainers from the community who are not employed by SUSE, or for projects which are open to this model, openSUSE is the organization to use. For openSUSE you can reach the administrators by writing to the public mailing list opensuse-project@opensuse.org.</p>
 
-    <p>No matter where the project lives, it will be open for collaboration and contributions from the community under the conditions of the chosen license. The GitHub organization only reflects the model of maintainership.</p>
+    <p>No matter where the project lives, it will be open for collaboration and contributions from the community under the conditions of the chosen licenses for both code and non-code. The GitHub organization only reflects the model of maintainership.</p>
 
     <p>We use a couple of other organizations on GitHub - for example, YaST or the Open Build Service. Use the respective channels to get in contact with them if your project falls under their umbrella.</p>
 
     <p>When creating new projects it is good practice to add a README.md and a CONTRIBUTING.md explaining the project and how to contribute.</p>
 
-    <p>When the project is part of a larger Open Source ecosystem, use the license which is usually used in this ecosystem. Otherwise choose a license compatible with the Open Source Definition, which matches the goal of the project and its interactions with other projects.</p>
+    <p>When the project is part of a larger Open Source ecosystem, use the license which is usually used in this ecosystem. Otherwise choose a license compatible with the Open Source Definition, which matches the goal of the project and its interactions with other projects. This applies to both code and non-code licenses; for example consider the Creative Commons license for documentation, Wiki and other non-code artifacts.</p>
 
-    <p>We typically don’t use contributor agreements for our own projects but rely on the Open Source licenses providing the necessary terms using the “inbound=outbound” model. This means that contributions are made under the same license under which the project is released.</p>
+    <p>We typically don't use contributor agreements for our own projects but rely on the Open Source licenses providing the necessary terms using the "inbound=outbound" model. This means that contributions are made under the same license under which the project is released.</p>
 
     <h3 id="copyright">Copyright</h3>
 
-    <p>The code you contribute upstream or publish as Open Source as part of your job at SUSE in your work time is copyrighted or otherwise owned by SUSE. Use “SUSE LLC” when attributing the copyright. Use your “@suse.com” email address for contributions.</p>
+    <p>The code you contribute upstream or publish as Open Source as part of your job at SUSE in your work time is copyrighted or otherwise owned by SUSE. Use "SUSE LLC" when attributing the copyright. Use your "@suse.com" email address for contributions.</p>
 
     <h3 id="respect">Respect</h3>
 
@@ -179,13 +179,23 @@
 
     <h3 id="factory-first">Factory First</h3>
 
-    <p>When packaging new Open Source software or adding changes to existing packages follow the “Factory First” model. “Factory” is the common code stream all our distributions are based on. It is the immediate source for openSUSE Tumbleweed and it eventually ends up in openSUSE Leap and the SUSE Linux Enterprise distributions. This is a continuation of the “Upstream First” principle on the distribution level. It reduces maintenance effort and leverages the community.</p>
+    <p>When packaging new Open Source software or adding changes to existing packages follow the "Factory First" model. <a href="https://susedefines.suse.com/definition/opensuse-factory/">"Factory"</a> is the common code stream all our distributions are based on. It is the immediate source for openSUSE Tumbleweed and it eventually ends up in openSUSE Leap and the SUSE Linux Enterprise distributions. This is a continuation of the "Upstream First" principle on the distribution level. It reduces maintenance effort and leverages the community.</p>
 
-    <p>“Factory First” extends to other SUSE products. Packages for all products should generally come from the common code stream our distributions are based on. So for packages you need in any products contribute them to factory first.</p>
+    <p>"Factory First" extends to other SUSE products. Packages for all products should generally come from the common code stream our distributions are based on. So for packages you need in any products contribute them to factory first.</p>
+
+    <h3 id="first-summary">"First" summary</h3>
+
+    <p>"Upstream first" applies to all individual upstream projects, such as the Linux kernel and nearly any package on SLE.</p>
+
+    <p>"Upstream first" also applies when there is an estalished upstream distribution, such as Tumbleweed (for SUSE Linux Enterprise) or Uyuni (for SUSE Manager)</p>
+
+    <p>"Factory first" applies to the SUSE Linux Enterprise family. It is recommended for things tightly connected to SUSE Linux Enterprise. It should also be considered (not necessarily adopted) for every SUSE product.</p>
+
+    <p>Creating an "intermediate upstream" distribution in between an existing upstream project (like Ceph, Kubernetes or Cloud Foundry) and a SUSE product is not recommended for nor against. It should be assessed on a case by ase base without bias, taking benefits and costs into account.</p>
 
     <h3 id="legal-review">Legal Review</h3>
 
-    <p>SUSE conducts a legal review of code we distribute in order to make sure we have the rights to distribute the code and that there are no legal issues such as license incompabilities. If you follow the Factory First approach and manage your code in the build service the legal review is automatically part of the process.</p>
+    <p>SUSE conducts a legal review of code we distribute in order to make sure we have the rights to distribute the code and that there are no legal issues such as license incompatibilities. If you follow the Factory First approach and manage your code in the build service the legal review is automatically part of the process.</p>
 
     <h2 id="patents">Patents</h2>
 
@@ -201,8 +211,8 @@
 
     <hr />
 
-    <p><em>Copyright 2018 SUSE LLC. This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</em></p>
-    <div class="version">Generated from open-source-policy.md v1.0.2</div>
+    <p><em>Copyright 2021 SUSE LLC. This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</em></p>
+    <div class="version">Generated from open-source-policy.md v1.0.3</div>
   </div>
   <div class='footer'>
     <a href="https://www.suse.com">www.suse.com</a>


### PR DESCRIPTION
This PR updates the Open Source Policy to version 1.0.3, which introduced a clarification on when "upstream first" or "factory first" are preferred. 

This was agreed with Thomas di Giacomo when he was still President of E&I but it has taken me some time to find out how to actually update opensource.suse.com (I thought updating SUSE/open-source-policy) was enough.

NB: this PR shows a lot of changes because of the changed quote and apostrophe characters. If you'd rather like a smaller diff, I can try to use the previous unicode characters.