### PR TITLE
GitHub discontinued v3 today, switch to v4

### DIFF
--- a/.github/workflows/gh-pages.deploy.yml
+++ b/.github/workflows/gh-pages.deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Bundle for saving
         run: tar --directory out/ -hcf artifact.tar .
       - name: Saving bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github-pages
           path: ./artifact.tar


### PR DESCRIPTION
https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/